### PR TITLE
关闭 `navigation.tracking` 选项

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -9,7 +9,6 @@ theme:
   name: material
   language: zh
   features:
-    - navigation.tracking
     - navigation.indexes
     - navigation.expand
     - navigation.top


### PR DESCRIPTION
[`navigation.tracking`](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=tracking#anchor-tracking) 选项启用后，URL 会跟踪当前正在浏览的 anchor。

目前我们认为，这个选项不应当启用，理由如下：

1. Anchor 本身具有 URL 定位的按钮，如果需要复制特定 anchor，更合理的做法是明确点击某个 anchor 然后复制 URL，因为 `tracking` 选项跟踪的 anchor 并不一定符合直觉；
2. 项目内大部分的文档都以中文撰写，而 anchor 大部分也为中文，导致浏览器自动转化的 URL 会因为中文转义而异常丑陋，为了提高「随手复制的」URL 的美观程度，应当尽可能减少中文在 URL 中出现的频率；